### PR TITLE
Add Makefile, CI workflow, and GitHub Actions hardening.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,16 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: cargo
     directory: /
     schedule:
       interval: weekly
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,98 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+
+      - name: Cache cargo
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Run tests
+        run: make test VERBOSE=1
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+          components: rustfmt
+
+      - name: Check formatting
+        run: make fmt-check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+          components: clippy
+
+      - name: Run Clippy
+        run: make clippy
+
+  audit:
+    name: Cargo Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
+
+      - name: Install cargo-audit
+        run: make audit-install
+
+      - name: Run cargo audit
+        run: make audit

--- a/.github/workflows/github-token-smoke.yml
+++ b/.github/workflows/github-token-smoke.yml
@@ -9,9 +9,12 @@ permissions:
 jobs:
   github-token:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -3,6 +3,9 @@ name: QA
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   local-qa:
     name: Local Runseal QA
@@ -10,13 +13,21 @@ jobs:
 
     steps:
       - name: Checkout runseal
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Checkout nono
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: always-further/nono
           path: nono
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
 
       - name: Install system dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,14 +6,17 @@ on:
       - "v*"
 
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
+  contents: read
 
 jobs:
   build:
     name: Build release binaries
+    if: github.repository == 'always-further/runseal'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -21,7 +24,14 @@ jobs:
           - x86_64-unknown-linux-gnu
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: stable
 
       - name: Build
         run: cargo build --release --locked --target ${{ matrix.target }}
@@ -41,7 +51,7 @@ jobs:
           echo "asset=dist/${asset}" >> "${GITHUB_OUTPUT}"
 
       - name: Attest release asset
-        uses: actions/attest@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: ${{ steps.package.outputs.asset }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Basic sandbox
         uses: always-further/runseal@main

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/
 /.DS_Store
+/runseal-lab/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,67 @@
+# Runseal - Makefile
+#
+# Usage:
+#   make          Build the CLI
+#   make test     Run unit tests
+#   make lint     Run clippy and format check (alias for check)
+#   make ci       Simulate CI (lint + test)
+
+.PHONY: all build test check lint clippy fmt fmt-check clean ci audit audit-install help
+
+CARGO ?= cargo
+export RUSTFLAGS ?= -Dwarnings
+
+TEST_FLAGS := --locked
+ifeq ($(VERBOSE),1)
+  TEST_FLAGS += --verbose
+endif
+
+all: build
+
+build:
+	$(CARGO) build --locked
+
+test:
+	$(CARGO) test $(TEST_FLAGS)
+
+check: clippy fmt-check
+
+lint: check
+
+clippy:
+	$(CARGO) clippy --all-targets --locked -- -D warnings
+
+fmt:
+	$(CARGO) fmt --all
+
+fmt-check:
+	$(CARGO) fmt --all -- --check
+
+audit-install:
+	$(CARGO) install cargo-audit --locked
+
+audit:
+	@command -v cargo-audit >/dev/null || { echo "cargo-audit not found; run make audit-install"; exit 1; }
+	$(CARGO) audit
+
+ci: lint test
+	@echo "CI checks passed"
+
+clean:
+	$(CARGO) clean
+
+help:
+	@echo "Runseal Makefile targets:"
+	@echo ""
+	@echo "  make build         Build the CLI (debug)"
+	@echo "  make test          Run unit tests (VERBOSE=1 for --verbose)"
+	@echo "  make lint          Run clippy and format check"
+	@echo "  make check         Same as lint"
+	@echo "  make clippy        Run clippy only"
+	@echo "  make fmt           Format code"
+	@echo "  make fmt-check     Check formatting"
+	@echo "  make audit-install Install cargo-audit"
+	@echo "  make audit         Run cargo audit"
+	@echo "  make ci            Run lint and test (same as CI rust jobs)"
+	@echo "  make clean         Remove build artifacts"
+	@echo "  make help          Show this help"

--- a/README.md
+++ b/README.md
@@ -286,6 +286,14 @@ Release assets are expected to use this naming scheme:
 ## Development
 
 ```bash
-cargo fmt
-cargo test
+make ci
+```
+
+`make ci` runs `make lint` and `make test` — the same Rust checks as the [CI workflow](.github/workflows/ci.yml).
+
+```bash
+make lint       # clippy + fmt check
+make test       # unit tests only
+make fmt        # format code
+make audit      # cargo audit (run make audit-install first)
 ```

--- a/action.yml
+++ b/action.yml
@@ -66,7 +66,7 @@ runs:
         RUNSEAL_AUDIT_DIR: ${{ runner.temp }}/runseal-audit
     - name: Upload Runseal audit
       if: ${{ always() && (inputs.audit == 'artifact' || inputs.audit == 'true') }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
       with:
         name: runseal-audit
         path: ${{ runner.temp }}/runseal-audit


### PR DESCRIPTION
Introduce make ci for local fmt/clippy/test, run the same checks in CI on push and pull requests, add Dependabot for Cargo and Actions, pin third-party actions to release SHAs, scope release permissions to the publish job, and restrict tagged releases to always-further/runseal.