### PR TITLE
fix(profile): block network when policy is blocked

### DIFF
--- a/src/profile.rs
+++ b/src/profile.rs
@@ -95,7 +95,7 @@ pub fn build_profile(config: &RunConfig, sealed: &SealedCredentials) -> Result<N
             exclude: excluded_groups(),
         },
         network: Network {
-            block: matches!(config.network, NetworkPolicy::Blocked) && credentials.is_empty(),
+            block: matches!(config.network, NetworkPolicy::Blocked),
             allow_domain: allow_domains.into_iter().collect(),
             credentials,
             custom_credentials,
@@ -212,6 +212,38 @@ mod tests {
 
         assert!(json.contains(r#""env_var":"CARGO_REGISTRY_TOKEN""#));
         assert!(!json.contains("RUNSEAL_ACCESS_CRATESIO_TOKEN"));
+    }
+
+    #[test]
+    fn generated_profile_blocks_network_when_credentials_are_configured() {
+        let config = RunConfig {
+            command: "true".to_string(),
+            fs_read: vec![".".to_string()],
+            fs_write: Vec::new(),
+            network: NetworkPolicy::Blocked,
+            access: Vec::new(),
+            audit: crate::config::AuditConfig::Disabled,
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sealed = SealedCredentials {
+            access: vec![SealedCredential {
+                name: "cratesio".to_string(),
+                secret_env: "CARGO_REGISTRY_TOKEN".to_string(),
+                upstream: "https://crates.io".to_string(),
+                tls_ca: None,
+                inject_mode: "header".to_string(),
+                credential_file: dir.path().join("cratesio"),
+                endpoint_rules: Vec::new(),
+            }],
+            dir,
+            sanitized_env: BTreeMap::new(),
+        };
+
+        let profile = build_profile(&config, &sealed).expect("profile");
+        let json: serde_json::Value =
+            serde_json::to_value(&profile).expect("profile serializes as JSON");
+
+        assert_eq!(json["network"]["block"], true);
     }
 
     #[test]

--- a/tests/profile_json.rs
+++ b/tests/profile_json.rs
@@ -1,0 +1,77 @@
+use std::env;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::process::Command;
+
+#[test]
+fn blocked_network_with_credentials_emits_block_true_profile_json() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let bin_dir = temp.path().join("bin");
+    fs::create_dir(&bin_dir).expect("create fake bin dir");
+
+    let fake_nono = bin_dir.join("nono");
+    fs::write(
+        &fake_nono,
+        r#"#!/bin/sh
+set -eu
+profile=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--profile" ]; then
+    shift
+    profile="$1"
+    break
+  fi
+  shift
+done
+cp "$profile" "$CAPTURED_PROFILE"
+"#,
+    )
+    .expect("write fake nono");
+    fs::set_permissions(&fake_nono, fs::Permissions::from_mode(0o755))
+        .expect("make fake nono executable");
+
+    let old_path = env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![bin_dir];
+    paths.extend(env::split_paths(&old_path));
+    let path = env::join_paths(paths).expect("join PATH");
+    let captured_profile = temp.path().join("profile.json");
+
+    let policy = r#"
+fs:
+  read: ["."]
+  write: []
+network:
+  mode: blocked
+access:
+  cratesio:
+    secret: CARGO_REGISTRY_TOKEN
+    url: https://crates.io
+    allow:
+      - GET /api/v1/crates
+"#;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_runseal"))
+        .arg("run")
+        .current_dir(temp.path())
+        .env("PATH", path)
+        .env("RUNSEAL_RUN", "true")
+        .env("RUNSEAL_POLICY", policy)
+        .env("RUNSEAL_AUDIT", "false")
+        .env("CARGO_REGISTRY_TOKEN", "test-token")
+        .env("CAPTURED_PROFILE", &captured_profile)
+        .output()
+        .expect("run runseal");
+
+    assert!(
+        output.status.success(),
+        "runseal failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&fs::read(captured_profile).expect("read captured profile"))
+            .expect("captured profile is JSON");
+
+    assert_eq!(json["network"]["block"], true);
+}


### PR DESCRIPTION
fix(profile): block network when policy is blocked

Previously, the `build_profile` function would not block network access if `NetworkPolicy::Blocked` was configured but credentials for specific domains were also provided. This allowed network access despite a blanket block policy being in place.

This change ensures that when `NetworkPolicy::Blocked` is set, the network is always blocked. Credentials for specific domains are intended to allow access to those domains *within* an otherwise blocked network, not to override the top-level block.

A new test has been added to verify that network blocking is correctly applied even when credentials are configured. This test is located in `tests/profile_json.rs`.