### PR TITLE
feat(profile): add filesystem deny for credential tempdir

### DIFF
--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1,6 +1,6 @@
 use crate::config::{NetworkPolicy, RunConfig};
 use crate::secrets::SealedCredentials;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
@@ -11,6 +11,8 @@ pub struct NonoProfile {
     extends: &'static str,
     meta: Meta,
     groups: Groups,
+    #[serde(skip_serializing_if = "Filesystem::is_empty")]
+    filesystem: Filesystem,
     network: Network,
 }
 
@@ -23,6 +25,18 @@ struct Meta {
 #[derive(Debug, Serialize)]
 struct Groups {
     exclude: Vec<&'static str>,
+}
+
+#[derive(Debug, Serialize)]
+struct Filesystem {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    deny: Vec<String>,
+}
+
+impl Filesystem {
+    fn is_empty(&self) -> bool {
+        self.deny.is_empty()
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -94,6 +108,9 @@ pub fn build_profile(config: &RunConfig, sealed: &SealedCredentials) -> Result<N
         groups: Groups {
             exclude: excluded_groups(),
         },
+        filesystem: Filesystem {
+            deny: credential_deny_paths(sealed)?,
+        },
         network: Network {
             block: matches!(config.network, NetworkPolicy::Blocked),
             allow_domain: allow_domains.into_iter().collect(),
@@ -101,6 +118,24 @@ pub fn build_profile(config: &RunConfig, sealed: &SealedCredentials) -> Result<N
             custom_credentials,
         },
     })
+}
+
+fn credential_deny_paths(sealed: &SealedCredentials) -> Result<Vec<String>> {
+    if sealed.access.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut paths = BTreeSet::new();
+    paths.insert(sealed.dir.path().display().to_string());
+
+    let canonical = sealed
+        .dir
+        .path()
+        .canonicalize()
+        .with_context(|| format!("failed to canonicalize '{}'", sealed.dir.path().display()))?;
+    paths.insert(canonical.display().to_string());
+
+    Ok(paths.into_iter().collect())
 }
 
 fn upstream_host(url: &str) -> Option<&str> {
@@ -244,6 +279,45 @@ mod tests {
             serde_json::to_value(&profile).expect("profile serializes as JSON");
 
         assert_eq!(json["network"]["block"], true);
+    }
+
+    #[test]
+    fn generated_profile_denies_credential_tempdir() {
+        let config = RunConfig {
+            command: "true".to_string(),
+            fs_read: vec![".".to_string()],
+            fs_write: Vec::new(),
+            network: NetworkPolicy::Blocked,
+            access: Vec::new(),
+            audit: crate::config::AuditConfig::Disabled,
+        };
+        let dir = tempfile::tempdir().expect("tempdir");
+        let credential_file = dir.path().join("cratesio");
+        let sealed = SealedCredentials {
+            access: vec![SealedCredential {
+                name: "cratesio".to_string(),
+                secret_env: "CARGO_REGISTRY_TOKEN".to_string(),
+                upstream: "https://crates.io".to_string(),
+                tls_ca: None,
+                inject_mode: "header".to_string(),
+                credential_file,
+                endpoint_rules: Vec::new(),
+            }],
+            dir,
+            sanitized_env: BTreeMap::new(),
+        };
+
+        let profile = build_profile(&config, &sealed).expect("profile");
+        let json: serde_json::Value =
+            serde_json::to_value(&profile).expect("profile serializes as JSON");
+        let denied = json["filesystem"]["deny"]
+            .as_array()
+            .expect("filesystem.deny is present");
+
+        assert!(denied.iter().any(|path| {
+            path.as_str()
+                .is_some_and(|path| path == sealed.dir.path().to_string_lossy())
+        }));
     }
 
     #[test]

--- a/tests/profile_json.rs
+++ b/tests/profile_json.rs
@@ -1,10 +1,104 @@
 use std::env;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 #[test]
 fn blocked_network_with_credentials_emits_block_true_profile_json() {
+    let policy = r#"
+fs:
+  read: ["."]
+  write: []
+network:
+  mode: blocked
+access:
+  cratesio:
+    secret: CARGO_REGISTRY_TOKEN
+    url: https://crates.io
+    allow:
+      - GET /api/v1/crates
+"#;
+    let run = run_with_fake_nono(policy);
+
+    assert!(
+        run.output.status.success(),
+        "runseal failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.output.stdout),
+        String::from_utf8_lossy(&run.output.stderr)
+    );
+
+    let json = read_profile_json(&run.captured_profile);
+
+    assert_eq!(json["network"]["block"], true);
+}
+
+#[test]
+fn tmp_read_grant_keeps_credential_file_under_profile_deny() {
+    let policy = r#"
+fs:
+  read: ["/tmp"]
+  write: []
+network:
+  mode: blocked
+access:
+  cratesio:
+    secret: CARGO_REGISTRY_TOKEN
+    url: https://crates.io
+    allow:
+      - GET /api/v1/crates
+"#;
+    let run = run_with_fake_nono(policy);
+
+    assert!(
+        run.output.status.success(),
+        "runseal failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.output.stdout),
+        String::from_utf8_lossy(&run.output.stderr)
+    );
+
+    let args = fs::read_to_string(&run.captured_args).expect("read captured nono args");
+    assert!(
+        args.lines()
+            .collect::<Vec<_>>()
+            .windows(2)
+            .any(|pair| pair == ["--read", "/tmp"]),
+        "expected broad /tmp read grant in nono args, got:\n{args}"
+    );
+
+    let json = read_profile_json(&run.captured_profile);
+    let credential_key = json["network"]["custom_credentials"]["cratesio"]["credential_key"]
+        .as_str()
+        .expect("credential key is present");
+    let credential_path = credential_key
+        .strip_prefix("file://")
+        .expect("credential key uses file://");
+    let credential_dir = Path::new(credential_path)
+        .parent()
+        .expect("credential file has parent");
+    let credential_dir = credential_dir.to_string_lossy();
+
+    let denied = json["filesystem"]["deny"]
+        .as_array()
+        .expect("filesystem.deny is present");
+    assert!(
+        denied.iter().any(|path| {
+            path.as_str()
+                .is_some_and(|path| path == credential_dir.as_ref())
+        }),
+        "credential file must remain unreadable via profile deny; denied={denied:?}, credential={}",
+        credential_dir
+    );
+}
+
+struct FakeNonoRun {
+    output: std::process::Output,
+    captured_profile: PathBuf,
+    captured_args: PathBuf,
+    _temp: tempfile::TempDir,
+}
+
+fn run_with_fake_nono(policy: &str) -> FakeNonoRun {
     let temp = tempfile::tempdir().expect("tempdir");
     let bin_dir = temp.path().join("bin");
     fs::create_dir(&bin_dir).expect("create fake bin dir");
@@ -14,6 +108,7 @@ fn blocked_network_with_credentials_emits_block_true_profile_json() {
         &fake_nono,
         r#"#!/bin/sh
 set -eu
+printf '%s\n' "$@" > "$CAPTURED_NONO_ARGS"
 profile=""
 while [ "$#" -gt 0 ]; do
   if [ "$1" = "--profile" ]; then
@@ -35,20 +130,7 @@ cp "$profile" "$CAPTURED_PROFILE"
     paths.extend(env::split_paths(&old_path));
     let path = env::join_paths(paths).expect("join PATH");
     let captured_profile = temp.path().join("profile.json");
-
-    let policy = r#"
-fs:
-  read: ["."]
-  write: []
-network:
-  mode: blocked
-access:
-  cratesio:
-    secret: CARGO_REGISTRY_TOKEN
-    url: https://crates.io
-    allow:
-      - GET /api/v1/crates
-"#;
+    let captured_args = temp.path().join("nono-args.txt");
 
     let output = Command::new(env!("CARGO_BIN_EXE_runseal"))
         .arg("run")
@@ -59,19 +141,19 @@ access:
         .env("RUNSEAL_AUDIT", "false")
         .env("CARGO_REGISTRY_TOKEN", "test-token")
         .env("CAPTURED_PROFILE", &captured_profile)
+        .env("CAPTURED_NONO_ARGS", &captured_args)
         .output()
         .expect("run runseal");
 
-    assert!(
-        output.status.success(),
-        "runseal failed\nstdout:\n{}\nstderr:\n{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
+    FakeNonoRun {
+        output,
+        captured_profile,
+        captured_args,
+        _temp: temp,
+    }
+}
 
-    let json: serde_json::Value =
-        serde_json::from_slice(&fs::read(captured_profile).expect("read captured profile"))
-            .expect("captured profile is JSON");
-
-    assert_eq!(json["network"]["block"], true);
+fn read_profile_json(path: &Path) -> serde_json::Value {
+    serde_json::from_slice(&fs::read(path).expect("read captured profile"))
+        .expect("captured profile is JSON")
 }


### PR DESCRIPTION
Introduce a new `filesystem.deny` section in the generated Nono profile. This section is populated with the paths to the temporary directory where sealed credentials are stored.

This is a security hardening measure to ensure that the sandboxed process cannot access its own credentials, even if a broad filesystem read grant (e.g., `/tmp`) is provided in the policy. The explicit denial ensures these sensitive paths remain inaccessible.

- Add `Filesystem` struct to `NonoProfile` to manage denied paths.
- Implement `credential_deny_paths` to collect and add credential tempdir paths.
- Add a test case to verify that the credential tempdir is denied, even when `/tmp` is broadly granted.