### PR TITLE
feat(config): add max policy yaml size limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
  "anyhow",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml_ng",
  "tempfile",
 ]
 
@@ -256,10 +256,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ path = "src/main.rs"
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yaml = "0.9"
+serde_yaml_ng = "0.10"
 tempfile = "3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,8 @@ use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use std::env;
 
+const MAX_POLICY_YAML_BYTES: usize = 64 * 1024;
+
 #[derive(Debug, Clone)]
 pub struct RunConfig {
     pub command: String,
@@ -107,8 +109,7 @@ impl RunConfig {
             .context("RUNSEAL_RUN is required")?;
 
         if let Some(policy_yaml) = env_value("RUNSEAL_POLICY") {
-            let policy: PolicyInput = serde_yaml::from_str(&policy_yaml)
-                .context("RUNSEAL_POLICY is not valid runseal policy YAML")?;
+            let policy = parse_policy_yaml(&policy_yaml)?;
             return Self::from_policy(command, policy);
         }
 
@@ -182,6 +183,18 @@ impl RunConfig {
             )?,
         })
     }
+}
+
+fn parse_policy_yaml(policy_yaml: &str) -> Result<PolicyInput> {
+    if policy_yaml.len() > MAX_POLICY_YAML_BYTES {
+        bail!(
+            "RUNSEAL_POLICY is too large ({} bytes); maximum is {} bytes",
+            policy_yaml.len(),
+            MAX_POLICY_YAML_BYTES
+        );
+    }
+
+    serde_yaml_ng::from_str(policy_yaml).context("RUNSEAL_POLICY is not valid runseal policy YAML")
 }
 
 fn env_value(name: &str) -> Option<String> {
@@ -258,7 +271,7 @@ mod tests {
 
     #[test]
     fn access_grant_without_allow_rules_fails_closed() {
-        let policy: PolicyInput = serde_yaml::from_str(
+        let policy = parse_policy_yaml(
             r#"
 access:
   cratesio:
@@ -280,7 +293,7 @@ access:
 
     #[test]
     fn access_grant_with_empty_allow_rules_fails_closed() {
-        let policy: PolicyInput = serde_yaml::from_str(
+        let policy = parse_policy_yaml(
             r#"
 access:
   cratesio:
@@ -303,7 +316,7 @@ access:
 
     #[test]
     fn access_grant_with_allow_rules_parses() {
-        let policy: PolicyInput = serde_yaml::from_str(
+        let policy = parse_policy_yaml(
             r#"
 access:
   cratesio:
@@ -321,5 +334,17 @@ access:
         assert_eq!(config.access[0].endpoint_rules.len(), 1);
         assert_eq!(config.access[0].endpoint_rules[0].method, "GET");
         assert_eq!(config.access[0].endpoint_rules[0].path, "/api/v1/crates");
+    }
+
+    #[test]
+    fn policy_yaml_over_size_limit_fails_before_parsing() {
+        let yaml = " ".repeat(MAX_POLICY_YAML_BYTES + 1);
+
+        let err = parse_policy_yaml(&yaml).expect_err("oversized policy must fail");
+
+        assert!(
+            err.to_string().contains("RUNSEAL_POLICY is too large"),
+            "unexpected error: {err:#}"
+        );
     }
 }


### PR DESCRIPTION
Upgrade serde_yaml to serde_yaml_ng and introduce a maximum size limit of 64KB for the RUNSEAL_POLICY YAML string.

- The previous `serde_yaml` crate is deprecated, `serde_yaml_ng` is its recommended successor.
- Limits the size of the `RUNSEAL_POLICY` environment variable to prevent potential resource exhaustion or denial-of-service attacks from excessively large policy configurations.
- Refactor policy YAML parsing into a dedicated function for better encapsulation and to enforce the new size limit before parsing.