### PR TITLE
fix(security): validate audit session ids and improve secret env handling

### DIFF
--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use std::collections::BTreeSet;
 use std::fs;
@@ -67,6 +67,7 @@ pub fn export_sessions(export: &AuditExport, output_dir: &Path) -> Result<()> {
     }
 
     for session in &export.sessions {
+        validate_session_id(session)?;
         let json = Command::new("nono")
             .arg("audit")
             .arg("show")
@@ -143,16 +144,31 @@ fn parse_audit_list_json(output: &str) -> Result<Vec<String>> {
 
     let entries: Vec<AuditListEntry> =
         serde_json::from_str(output).context("failed to parse nono audit list --json output")?;
-    Ok(entries
-        .into_iter()
-        .map(|entry| entry.session_id)
-        .filter(|session| !session.trim().is_empty())
-        .collect())
+    let mut sessions = Vec::new();
+    for entry in entries {
+        if entry.session_id.trim().is_empty() {
+            continue;
+        }
+        validate_session_id(&entry.session_id)?;
+        sessions.push(entry.session_id);
+    }
+    Ok(sessions)
 }
 
 fn parse_session_id(line: &str) -> Option<&str> {
     line.split_whitespace()
-        .find(|part| part.chars().all(|ch| ch.is_ascii_digit() || ch == '-'))
+        .find(|part| is_valid_session_id(part))
+}
+
+fn validate_session_id(session: &str) -> Result<()> {
+    if !is_valid_session_id(session) {
+        bail!("nono audit session id '{session}' is invalid");
+    }
+    Ok(())
+}
+
+fn is_valid_session_id(session: &str) -> bool {
+    !session.is_empty() && session.chars().all(|ch| ch.is_ascii_digit() || ch == '-')
 }
 
 #[cfg(test)]
@@ -194,6 +210,62 @@ mod tests {
         assert_eq!(
             sessions,
             vec!["20260606-184133-1234", "20260606-184200-5678"]
+        );
+    }
+
+    #[test]
+    fn rejects_traversal_session_ids_from_json_list() {
+        let err = parse_audit_list_json(
+            r#"[
+              {
+                "session_id": "../../../../tmp/evil",
+                "command": "true"
+              }
+            ]"#,
+        )
+        .expect_err("traversal session id must fail");
+
+        assert!(
+            err.to_string().contains("session id"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn rejects_absolute_session_ids_from_json_list() {
+        let err = parse_audit_list_json(
+            r#"[
+              {
+                "session_id": "/tmp/evil",
+                "command": "true"
+              }
+            ]"#,
+        )
+        .expect_err("absolute session id must fail");
+
+        assert!(
+            err.to_string().contains("session id"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn export_rejects_invalid_session_ids_before_writing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let export = AuditExport {
+            sessions: vec!["../../evil".to_string()],
+            used_latest_fallback: false,
+        };
+
+        let err = export_sessions(&export, dir.path()).expect_err("invalid session id must fail");
+
+        assert!(
+            err.to_string().contains("session id"),
+            "unexpected error: {err:#}"
+        );
+        assert!(
+            !dir.path().join("evil.error.txt").exists(),
+            "invalid session id must not be written"
         );
     }
 

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -31,7 +31,12 @@ pub fn seal_credentials(config: &RunConfig) -> Result<SealedCredentials> {
     fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o700))?;
 
     let secret_names: HashSet<&str> = config.access.iter().map(|c| c.secret.as_str()).collect();
-    let sanitized_env: BTreeMap<String, String> = env::vars()
+    let sanitized_env: BTreeMap<String, String> = env::vars_os()
+        .filter_map(|(key, value)| {
+            let key = key.into_string().ok()?;
+            let value = value.into_string().ok()?;
+            Some((key, value))
+        })
         .filter(|(key, _)| !secret_names.contains(key.as_str()))
         .filter(|(key, _)| !key.starts_with("RUNSEAL_"))
         .filter(|(key, _)| !key.starts_with("NONO_ACTION_"))
@@ -41,8 +46,7 @@ pub fn seal_credentials(config: &RunConfig) -> Result<SealedCredentials> {
     for grant in &config.access {
         validate_access_grant_name(&grant.name)?;
 
-        let secret = env::var(&grant.secret)
-            .with_context(|| format!("access secret env var '{}' is not set", grant.secret))?;
+        let secret = read_secret_env(&grant.secret)?;
         if secret.is_empty() {
             bail!("access secret env var '{}' is empty", grant.secret);
         }
@@ -70,6 +74,15 @@ pub fn seal_credentials(config: &RunConfig) -> Result<SealedCredentials> {
         access: sealed,
         sanitized_env,
     })
+}
+
+fn read_secret_env(secret_env: &str) -> Result<String> {
+    let value = env::var_os(secret_env)
+        .with_context(|| format!("access secret env var '{secret_env}' is not set"))?;
+    match value.into_string() {
+        Ok(value) => Ok(value),
+        Err(_) => bail!("access secret env var '{secret_env}' is not valid UTF-8"),
+    }
 }
 
 fn validate_access_grant_name(name: &str) -> Result<()> {
@@ -115,6 +128,8 @@ fn secret_mask_lines(secret: &str) -> impl Iterator<Item = &str> {
 mod tests {
     use super::*;
     use crate::config::{AccessConfig, AuditConfig, NetworkPolicy};
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
 
     #[test]
     fn validates_safe_access_grant_names() {
@@ -164,6 +179,30 @@ mod tests {
         assert!(
             err.to_string().contains("access grant name"),
             "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn non_utf8_secret_error_does_not_include_raw_value() {
+        let name = "RUNSEAL_TEST_NON_UTF8_SECRET";
+        let value = OsString::from_vec(b"TOPSECRET-\xFF\xFE-RAWKEY".to_vec());
+        env::set_var(name, &value);
+
+        let err = read_secret_env(name).expect_err("non-UTF-8 secret must fail");
+        env::remove_var(name);
+
+        let rendered = format!("{err:#}");
+        assert!(
+            rendered.contains("not valid UTF-8"),
+            "unexpected error: {rendered}"
+        );
+        assert!(
+            !rendered.contains("TOPSECRET"),
+            "error leaked secret prefix: {rendered}"
+        );
+        assert!(
+            !rendered.contains("RAWKEY"),
+            "error leaked secret suffix: {rendered}"
         );
     }
 


### PR DESCRIPTION
validate all audit session identifiers
- introduce `is_valid_session_id` and `validate_session_id` functions.
- apply validation when parsing sessions from `nono audit list --json` output.
- apply validation before exporting sessions.
- prevent the use of malformed or potentially malicious session IDs (e.g., path traversal segments) which could lead to unexpected file paths.

improve environment variable handling for secrets
- switch from `env::vars()` to `env::vars_os()` when sanitizing the environment, allowing for graceful handling of non-UTF-8 environment variables by filtering them out.
- update secret reading to ensure non-UTF-8 secret values do not lead to information leakage in error messages. A specific error is now reported without exposing the raw bytes of the secret.