### PR TITLE
chore(release): bump project version to 0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "runseal"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runseal"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 license = "Apache-2.0"
 description = "GitHub Actions security wrapper for nono sandboxed credential use"


### PR DESCRIPTION
Updates the project version in `Cargo.toml` and `Cargo.lock`.