### PR TITLE
refactor(config): swap stringly-typing for enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Runseal expects `network.mode: blocked` or `network.mode: filtered`.
 
 Add `network.allow` only for unauthenticated hosts the command must reach. Hosts
 used by access grants are added to the generated `nono` profile automatically.
+A `network.allow` list implies `mode: filtered` when `mode` is omitted;
+combining it with an explicit `mode: blocked` is a configuration error.
 
 ```yaml
 network:

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ still allowing L7 policy enforcement.
 | `policy` | No | empty | Runseal policy YAML. Prefer this for new workflows. |
 | `fs-read` | No | empty | Comma-separated read paths when `policy` is not set. |
 | `fs-write` | No | empty | Comma-separated write paths when `policy` is not set. |
-| `network` | No | `blocked` | Network policy when `policy` is not set: `blocked` or comma-separated domains. |
+| `network` | No | `blocked` | Network policy when `policy` is not set: `blocked` or comma-separated domains. `filtered` is only valid as `network.mode` inside `policy` and is rejected here. |
 | `runseal-version` | No | `0.3.1` | Runseal release version to install. Accepts `v0.1.0` or `0.1.0`. |
 | `nono-version` | No | `0.62.0` | nono release version to install. Accepts `v0.1.0` or `0.1.0`. |
 | `verify-attestations` | No | `true` | Verify GitHub artifact attestations for downloaded release assets. |

--- a/README.md
+++ b/README.md
@@ -143,6 +143,26 @@ The sandboxed command receives a phantom credential for SDK compatibility. The
 real secret remains outside the sandbox and is only inserted by the proxy when
 the host and endpoint policy match.
 
+`inject.mode` selects how the proxy injects the secret:
+
+| Mode | Status | Behavior |
+| --- | --- | --- |
+| `header` | Default | Injected as an `Authorization: Bearer` header. |
+| `basic_auth` | Supported | Injected as HTTP basic auth credentials. |
+| `url_path` | Reserved | Rejected; runseal does not emit the required `path_pattern` yet. |
+| `query_param` | Reserved | Rejected; runseal does not emit the required `query_param_name` yet. |
+
+```yaml
+access:
+  fly:
+    secret: FLY_API_TOKEN
+    url: https://api.machines.dev
+    inject:
+      mode: header
+    allow:
+      - POST /v1/apps/*/machines
+```
+
 ### HTTPS Endpoint Filtering
 
 `allow` restricts access use by HTTP method and path. Matching is allow-list

--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ access:
 ### HTTPS Endpoint Filtering
 
 `allow` restricts access use by HTTP method and path. Matching is allow-list
-based.
+based. The method may be any HTTP method token (`GET`, `DELETE`, `PROPFIND`,
+...) or the wildcard `*`; methods are uppercased before matching.
 
 ```yaml
 allow:

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,13 @@ pub enum NetworkPolicy {
     AllowDomains(Vec<String>),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum NetworkMode {
+    Blocked,
+    Filtered,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AuditConfig {
     Disabled,
@@ -92,10 +99,22 @@ struct FsInput {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct NetworkInput {
-    #[serde(default = "default_blocked")]
-    mode: String,
+    #[serde(default, deserialize_with = "explicit_network_mode")]
+    mode: Option<NetworkMode>,
     #[serde(default)]
     allow: Vec<String>,
+}
+
+/// An omitted `mode` key means "infer from the allow list", but a present key
+/// must carry a real mode: an explicit null (`mode:` / `mode: ~`) is rejected
+/// rather than silently aliased to the omitted case.
+fn explicit_network_mode<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<NetworkMode>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    NetworkMode::deserialize(deserializer).map(Some)
 }
 
 #[derive(Debug, Deserialize)]
@@ -118,9 +137,6 @@ struct InjectInput {
     mode: InjectMode,
 }
 
-fn default_blocked() -> String {
-    "blocked".to_string()
-}
 impl RunConfig {
     pub fn from_action_env() -> Result<Self> {
         let command = env_value("RUNSEAL_RUN")
@@ -164,19 +180,15 @@ impl RunConfig {
     fn from_policy(command: String, policy: PolicyInput) -> Result<Self> {
         let (fs_read, fs_write) = policy.fs.map(|fs| (fs.read, fs.write)).unwrap_or_default();
         let network = match policy.network {
-            Some(network)
-                if matches!(network.mode.as_str(), "blocked" | "filtered")
-                    && network.allow.is_empty() =>
-            {
-                NetworkPolicy::Blocked
-            }
-            Some(network) if matches!(network.mode.as_str(), "blocked" | "filtered") => {
-                NetworkPolicy::AllowDomains(network.allow)
-            }
-            Some(network) => bail!(
-                "unsupported network.mode '{}'; expected 'blocked' or 'filtered'",
-                network.mode
-            ),
+            Some(network) if network.allow.is_empty() => NetworkPolicy::Blocked,
+            Some(network) => match network.mode {
+                Some(NetworkMode::Blocked) => bail!(
+                    "network.mode 'blocked' cannot be combined with network.allow; use mode 'filtered' or remove the allow list"
+                ),
+                // An allow list without an explicit mode has always meant a
+                // domain allowlist; only a stated 'blocked' contradicts it.
+                Some(NetworkMode::Filtered) | None => NetworkPolicy::AllowDomains(network.allow),
+            },
             None => NetworkPolicy::Blocked,
         };
         let mut access = Vec::new();
@@ -362,6 +374,97 @@ access:
         assert_eq!(config.access[0].endpoint_rules.len(), 1);
         assert_eq!(config.access[0].endpoint_rules[0].method, "GET");
         assert_eq!(config.access[0].endpoint_rules[0].path, "/api/v1/crates");
+    }
+
+    #[test]
+    fn explicit_null_network_mode_fails_to_parse() {
+        for policy in [
+            "network:\n  mode:\n  allow:\n    - api.github.com\n",
+            "network:\n  mode: ~\n  allow:\n    - api.github.com\n",
+        ] {
+            let err = parse_policy_yaml(policy).expect_err("null network mode must fail");
+
+            assert!(
+                format!("{err:#}").contains("not valid runseal policy YAML"),
+                "unexpected error: {err:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn blocked_network_mode_with_allow_list_fails_closed() {
+        let policy = parse_policy_yaml(
+            r#"
+network:
+  mode: blocked
+  allow:
+    - api.github.com
+"#,
+        )
+        .expect("policy yaml");
+
+        let err = RunConfig::from_policy("true".to_string(), policy)
+            .expect_err("blocked mode with allow list must fail");
+
+        assert!(
+            err.to_string()
+                .contains("network.mode 'blocked' cannot be combined with network.allow"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn filtered_network_mode_with_allow_list_allows_domains() {
+        let policy = parse_policy_yaml(
+            r#"
+network:
+  mode: filtered
+  allow:
+    - api.github.com
+"#,
+        )
+        .expect("policy yaml");
+
+        let config = RunConfig::from_policy("true".to_string(), policy).expect("policy parses");
+
+        assert_eq!(
+            config.network,
+            NetworkPolicy::AllowDomains(vec!["api.github.com".to_string()])
+        );
+    }
+
+    #[test]
+    fn allow_list_without_mode_allows_domains() {
+        let policy = parse_policy_yaml(
+            r#"
+network:
+  allow:
+    - api.github.com
+"#,
+        )
+        .expect("policy yaml");
+
+        let config = RunConfig::from_policy("true".to_string(), policy).expect("policy parses");
+
+        assert_eq!(
+            config.network,
+            NetworkPolicy::AllowDomains(vec!["api.github.com".to_string()])
+        );
+    }
+
+    #[test]
+    fn filtered_network_mode_without_allow_list_blocks_network() {
+        let policy = parse_policy_yaml(
+            r#"
+network:
+  mode: filtered
+"#,
+        )
+        .expect("policy yaml");
+
+        let config = RunConfig::from_policy("true".to_string(), policy).expect("policy parses");
+
+        assert_eq!(config.network, NetworkPolicy::Blocked);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -260,7 +260,7 @@ fn parse_network(value: Option<&str>) -> NetworkPolicy {
 }
 
 fn parse_audit(value: Option<&str>, dir: Option<&str>) -> Result<AuditConfig> {
-    match value.unwrap_or("false").trim() {
+    match value.unwrap_or_default().trim() {
         "" | "false" | "off" | "none" => Ok(AuditConfig::Disabled),
         "true" | "artifact" => {
             let dir = dir
@@ -270,7 +270,9 @@ fn parse_audit(value: Option<&str>, dir: Option<&str>) -> Result<AuditConfig> {
                 dir: dir.to_string(),
             })
         }
-        value => bail!("unsupported audit mode '{value}'; expected 'false' or 'artifact'"),
+        value => bail!(
+            "unsupported audit mode '{value}'; expected one of 'false', 'off', 'none', 'true', 'artifact'"
+        ),
     }
 }
 
@@ -374,6 +376,56 @@ access:
         assert_eq!(config.access[0].endpoint_rules.len(), 1);
         assert_eq!(config.access[0].endpoint_rules[0].method, "GET");
         assert_eq!(config.access[0].endpoint_rules[0].path, "/api/v1/crates");
+    }
+
+    #[test]
+    fn audit_mode_aliases_parse() {
+        for value in ["", "false", "off", "none", " false "] {
+            assert_eq!(
+                parse_audit(Some(value), None).expect("disabled alias"),
+                AuditConfig::Disabled,
+                "value {value:?}"
+            );
+        }
+        assert_eq!(
+            parse_audit(None, None).expect("unset"),
+            AuditConfig::Disabled
+        );
+        for value in ["true", "artifact"] {
+            assert_eq!(
+                parse_audit(Some(value), None).expect("artifact alias"),
+                AuditConfig::Artifact {
+                    dir: "runseal-audit".to_string()
+                },
+                "value {value:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn audit_artifact_uses_configured_dir() {
+        assert_eq!(
+            parse_audit(Some("artifact"), Some("/tmp/audit")).expect("artifact"),
+            AuditConfig::Artifact {
+                dir: "/tmp/audit".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_network_mode_fails_to_parse() {
+        let err = parse_policy_yaml(
+            r#"
+network:
+  mode: open
+"#,
+        )
+        .expect_err("unknown network mode must fail");
+
+        assert!(
+            format!("{err:#}").contains("not valid runseal policy YAML"),
+            "unexpected error: {err:#}"
+        );
     }
 
     #[test]
@@ -513,7 +565,6 @@ access:
         );
     }
 
-    #[test]
     #[test]
     fn unsupported_inject_mode_fails_closed() {
         let policy = parse_policy_yaml(

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,13 +26,43 @@ pub enum AuditConfig {
     Artifact { dir: String },
 }
 
+/// Secret injection modes in nono's wire format
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum InjectMode {
+    #[default]
+    Header,
+    UrlPath,
+    QueryParam,
+    BasicAuth,
+}
+
+impl InjectMode {
+    fn wire_name(self) -> &'static str {
+        match self {
+            InjectMode::Header => "header",
+            InjectMode::UrlPath => "url_path",
+            InjectMode::QueryParam => "query_param",
+            InjectMode::BasicAuth => "basic_auth",
+        }
+    }
+}
+
+/// The inject modes runseal can emit a complete nono credential entry for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SupportedInjectMode {
+    Header,
+    BasicAuth,
+}
+
 #[derive(Debug, Clone)]
 pub struct AccessConfig {
     pub name: String,
     pub secret: String,
     pub upstream: String,
     pub tls_ca: Option<String>,
-    pub inject_mode: String,
+    pub inject_mode: SupportedInjectMode,
     pub endpoint_rules: Vec<EndpointRule>,
 }
 
@@ -81,26 +111,15 @@ struct AccessInput {
     allow: Vec<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct InjectInput {
-    #[serde(default = "default_header_mode")]
-    mode: String,
-}
-
-impl Default for InjectInput {
-    fn default() -> Self {
-        Self {
-            mode: default_header_mode(),
-        }
-    }
+    #[serde(default)]
+    mode: InjectMode,
 }
 
 fn default_blocked() -> String {
     "blocked".to_string()
-}
-fn default_header_mode() -> String {
-    "header".to_string()
 }
 impl RunConfig {
     pub fn from_action_env() -> Result<Self> {
@@ -162,12 +181,20 @@ impl RunConfig {
         };
         let mut access = Vec::new();
         for (name, grant) in policy.access.unwrap_or_default() {
+            let inject_mode = match grant.inject.mode {
+                InjectMode::Header => SupportedInjectMode::Header,
+                InjectMode::BasicAuth => SupportedInjectMode::BasicAuth,
+                mode @ (InjectMode::UrlPath | InjectMode::QueryParam) => bail!(
+                    "access grant '{name}' uses inject.mode '{}', which is not yet supported by runseal; use 'header' or 'basic_auth'",
+                    mode.wire_name()
+                ),
+            };
             access.push(AccessConfig {
                 name,
                 secret: grant.secret,
                 upstream: validate_url(&grant.url)?,
                 tls_ca: grant.tls_ca,
-                inject_mode: grant.inject.mode,
+                inject_mode,
                 endpoint_rules: parse_allow_rules(&grant.allow)?,
             });
         }
@@ -279,7 +306,7 @@ access:
     url: https://crates.io
 "#,
         )
-        .expect("policy yaml");
+        .expect("Valid policy yaml");
 
         let err = RunConfig::from_policy("true".to_string(), policy)
             .expect_err("missing allow rules must fail");
@@ -302,7 +329,7 @@ access:
     allow: []
 "#,
         )
-        .expect("policy yaml");
+        .expect("Valid policy yaml");
 
         let err = RunConfig::from_policy("true".to_string(), policy)
             .expect_err("empty allow rules must fail");
@@ -326,14 +353,88 @@ access:
       - GET /api/v1/crates
 "#,
         )
-        .expect("policy yaml");
+        .expect("Valid policy yaml");
 
-        let config = RunConfig::from_policy("true".to_string(), policy).expect("policy parses");
+        let config = RunConfig::from_policy("true".to_string(), policy)
+            .expect("Policy should parse correctly");
 
         assert_eq!(config.access.len(), 1);
         assert_eq!(config.access[0].endpoint_rules.len(), 1);
         assert_eq!(config.access[0].endpoint_rules[0].method, "GET");
         assert_eq!(config.access[0].endpoint_rules[0].path, "/api/v1/crates");
+    }
+
+    #[test]
+    fn access_grant_defaults_to_header_inject_mode() {
+        let policy = parse_policy_yaml(
+            r#"
+access:
+  cratesio:
+    secret: CARGO_REGISTRY_TOKEN
+    url: https://crates.io
+    allow:
+      - GET /api/v1/crates
+"#,
+        )
+        .expect("Valid policy yaml");
+
+        let config = RunConfig::from_policy("true".to_string(), policy)
+            .expect("Policy should parse correctly");
+
+        assert_eq!(config.access[0].inject_mode, SupportedInjectMode::Header);
+    }
+
+    #[test]
+    fn basic_auth_inject_mode_maps_and_serializes_as_snake_case() {
+        let policy = parse_policy_yaml(
+            r#"
+access:
+  cratesio:
+    secret: CARGO_REGISTRY_TOKEN
+    url: https://crates.io
+    inject:
+      mode: basic_auth
+    allow:
+      - GET /api/v1/crates
+"#,
+        )
+        .expect("Valid policy yaml");
+
+        let config = RunConfig::from_policy("true".to_string(), policy)
+            .expect("Policy should parse correctly");
+
+        assert_eq!(config.access[0].inject_mode, SupportedInjectMode::BasicAuth);
+        assert_eq!(
+            serde_json::to_string(&config.access[0].inject_mode).expect("Valid json"),
+            r#""basic_auth""#
+        );
+    }
+
+    #[test]
+    #[test]
+    fn unsupported_inject_mode_fails_closed() {
+        let policy = parse_policy_yaml(
+            r#"
+access:
+  cratesio:
+    secret: CARGO_REGISTRY_TOKEN
+    url: https://crates.io
+    inject:
+      mode: url_path
+    allow:
+      - GET /api/v1/crates
+"#,
+        )
+        .expect("Valid policy yaml");
+
+        let err = RunConfig::from_policy("true".to_string(), policy)
+            .expect_err("unsupported inject mode must fail");
+
+        assert!(
+            err.to_string()
+                .contains("inject.mode 'url_path', which is not yet supported"),
+            "unexpected error: {err:#}"
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,10 +73,39 @@ pub struct AccessConfig {
     pub endpoint_rules: Vec<EndpointRule>,
 }
 
-#[derive(Debug, Clone, Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct EndpointRule {
-    pub method: String,
+    pub method: HttpMethod,
     pub path: String,
+}
+
+/// An HTTP method in nono's wire format: an uppercased RFC 7230 method token
+/// or the '*' wildcard. nono accepts arbitrary method strings (TRACE, CONNECT,
+/// WebDAV verbs, ...).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(transparent)]
+pub struct HttpMethod(String);
+
+impl std::str::FromStr for HttpMethod {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        // The wildcard is only meaningful to nono as the exact string "*", so
+        // '*' is rejected inside longer tokens ("**", "GET*") even though RFC
+        // 7230 technically  allows it, as these rules would silently never
+        // match any request.
+        if value == "*" {
+            return Ok(Self("*".to_string()));
+        }
+        let is_token = !value.is_empty()
+            && value
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || b"!#$%&'+-.^_`|~".contains(&byte));
+        if !is_token {
+            bail!("invalid HTTP method '{value}'; expected a method token like GET, or '*'");
+        }
+        Ok(Self(value.to_ascii_uppercase()))
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -332,8 +361,11 @@ fn parse_allow_rules(allow: &[String]) -> Result<Vec<EndpointRule>> {
             if method.is_empty() || path.is_empty() {
                 bail!("access allow rule '{rule}' must be formatted as 'METHOD /path'");
             }
+            let method = method
+                .parse::<HttpMethod>()
+                .with_context(|| format!("access allow rule '{rule}' has an unsupported method"))?;
             Ok(EndpointRule {
-                method: method.to_string(),
+                method,
                 path: path.to_string(),
             })
         })
@@ -343,6 +375,10 @@ fn parse_allow_rules(allow: &[String]) -> Result<Vec<EndpointRule>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn method(token: &str) -> HttpMethod {
+        token.parse().expect("method token")
+    }
 
     #[test]
     fn access_grant_without_allow_rules_fails_closed() {
@@ -408,8 +444,74 @@ access:
 
         assert_eq!(config.access.len(), 1);
         assert_eq!(config.access[0].endpoint_rules.len(), 1);
-        assert_eq!(config.access[0].endpoint_rules[0].method, "GET");
+        assert_eq!(config.access[0].endpoint_rules[0].method, method("GET"));
         assert_eq!(config.access[0].endpoint_rules[0].path, "/api/v1/crates");
+    }
+
+    #[test]
+    fn allow_rule_methods_parse_case_insensitively_with_wildcard() {
+        let rules = parse_allow_rules(&[
+            "get /a".to_string(),
+            "POST /b".to_string(),
+            "* /c".to_string(),
+        ])
+        .expect("allow rules parse");
+
+        assert_eq!(rules[0].method, method("GET"));
+        assert_eq!(rules[1].method, method("POST"));
+        assert_eq!(rules[2].method, method("*"));
+    }
+
+    #[test]
+    fn allow_rule_methods_accept_arbitrary_method_tokens() {
+        let rules = parse_allow_rules(&[
+            "TRACE /a".to_string(),
+            "connect /b".to_string(),
+            "PROPFIND /c".to_string(),
+            "version-control /d".to_string(),
+        ])
+        .expect("allow rules parse");
+
+        assert_eq!(rules[0].method, method("TRACE"));
+        assert_eq!(rules[1].method, method("CONNECT"));
+        assert_eq!(rules[2].method, method("PROPFIND"));
+        assert_eq!(rules[3].method, method("VERSION-CONTROL"));
+    }
+
+    #[test]
+    fn allow_rule_with_wildcard_inside_method_token_fails_closed() {
+        for method in ["**", "GET*", "*GET", "G*T"] {
+            let err = parse_allow_rules(&[format!("{method} /a")])
+                .expect_err("wildcard inside a method token must fail");
+
+            assert!(
+                format!("{err:#}").contains(&format!("invalid HTTP method '{method}'")),
+                "unexpected error: {err:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn allow_rule_with_malformed_method_fails_closed() {
+        for method in ["GE/T", "GÉT", "GET;"] {
+            let err = parse_allow_rules(&[format!("{method} /a")])
+                .expect_err("malformed method must fail");
+
+            assert!(
+                format!("{err:#}").contains(&format!("invalid HTTP method '{method}'")),
+                "unexpected error: {err:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn allow_rule_methods_serialize_as_uppercase_wire_strings() {
+        let rules =
+            parse_allow_rules(&["get /a".to_string(), "* /c".to_string()]).expect("rules parse");
+        let json = serde_json::to_string(&rules).expect("json");
+
+        assert!(json.contains(r#""method":"GET""#), "json: {json}");
+        assert!(json.contains(r#""method":"*""#), "json: {json}");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -162,7 +162,7 @@ impl RunConfig {
             env_value("RUNSEAL_NETWORK")
                 .or_else(|| env_value("NONO_ACTION_NETWORK"))
                 .as_deref(),
-        );
+        )?;
         let audit = parse_audit(
             env_value("RUNSEAL_AUDIT").as_deref(),
             env_value("RUNSEAL_AUDIT_DIR").as_deref(),
@@ -187,7 +187,9 @@ impl RunConfig {
                 ),
                 // An allow list without an explicit mode has always meant a
                 // domain allowlist; only a stated 'blocked' contradicts it.
-                Some(NetworkMode::Filtered) | None => NetworkPolicy::AllowDomains(network.allow),
+                Some(NetworkMode::Filtered) | None => {
+                    NetworkPolicy::AllowDomains(validate_domain_allowlist(network.allow)?)
+                }
             },
             None => NetworkPolicy::Blocked,
         };
@@ -250,12 +252,44 @@ fn split_csv(value: Option<&str>) -> Vec<String> {
         .collect()
 }
 
-fn parse_network(value: Option<&str>) -> NetworkPolicy {
-    let raw = value.unwrap_or("blocked").trim();
-    if raw.is_empty() || raw == "blocked" {
-        NetworkPolicy::Blocked
-    } else {
-        NetworkPolicy::AllowDomains(split_csv(Some(raw)))
+fn is_network_mode_keyword(value: &str) -> bool {
+    value.eq_ignore_ascii_case("blocked") || value.eq_ignore_ascii_case("filtered")
+}
+
+/// Trims and rejects entries that cannot be domains.
+fn validate_domain_allowlist(domains: Vec<String>) -> Result<Vec<String>> {
+    let domains: Vec<String> = domains
+        .into_iter()
+        .map(|domain| domain.trim().to_string())
+        .collect();
+    for domain in &domains {
+        if domain.is_empty() {
+            bail!("network.allow entries must not be empty");
+        }
+        if is_network_mode_keyword(domain) {
+            bail!(
+                "network.allow entry '{domain}' is not a domain; 'blocked' and 'filtered' belong in network.mode"
+            );
+        }
+    }
+    Ok(domains)
+}
+
+fn parse_network(value: Option<&str>) -> Result<NetworkPolicy> {
+    let domains = split_csv(value);
+    match domains.as_slice() {
+        [] => Ok(NetworkPolicy::Blocked),
+        [only] if only.eq_ignore_ascii_case("blocked") => Ok(NetworkPolicy::Blocked),
+        _ => {
+            for domain in &domains {
+                if is_network_mode_keyword(domain) {
+                    bail!(
+                        "network value '{domain}' is not a domain; set RUNSEAL_NETWORK to 'blocked' or a comma-separated domain allowlist (network.mode 'filtered' belongs in policy YAML)"
+                    );
+                }
+            }
+            Ok(NetworkPolicy::AllowDomains(domains))
+        }
     }
 }
 
@@ -379,6 +413,55 @@ access:
     }
 
     #[test]
+    fn network_env_blocked_or_unset_blocks_network() {
+        for value in [
+            None,
+            Some(""),
+            Some("blocked"),
+            Some(" blocked "),
+            Some("Blocked"),
+            Some("BLOCKED"),
+            Some("blocked,"),
+        ] {
+            assert_eq!(
+                parse_network(value).expect("blocked network"),
+                NetworkPolicy::Blocked,
+                "value {value:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn network_env_domain_list_allows_domains() {
+        assert_eq!(
+            parse_network(Some("a.com, b.com")).expect("domain list"),
+            NetworkPolicy::AllowDomains(vec!["a.com".to_string(), "b.com".to_string()])
+        );
+    }
+
+    #[test]
+    fn network_env_rejects_mode_keywords_as_domains() {
+        for value in [
+            "filtered",
+            "Filtered",
+            "FILTERED",
+            "a.com,blocked",
+            "a.com,Blocked",
+            "a.com,BLOCKED",
+            "a.com, filtered",
+            "a.com, FILTERED",
+        ] {
+            let err =
+                parse_network(Some(value)).expect_err("mode keyword must not become a domain");
+
+            assert!(
+                err.to_string().contains("is not a domain"),
+                "unexpected error for {value:?}: {err:#}"
+            );
+        }
+    }
+
+    #[test]
     fn audit_mode_aliases_parse() {
         for value in ["", "false", "off", "none", " false "] {
             assert_eq!(
@@ -441,6 +524,46 @@ network:
                 "unexpected error: {err:#}"
             );
         }
+    }
+
+    #[test]
+    fn policy_allow_list_rejects_mode_keywords_and_blank_entries() {
+        for (entry, expected) in [
+            ("blocked", "is not a domain"),
+            ("Filtered", "is not a domain"),
+            ("''", "must not be empty"),
+            ("'  '", "must not be empty"),
+        ] {
+            let policy = parse_policy_yaml(&format!("network:\n  allow:\n    - {entry}\n"))
+                .expect("policy yaml");
+
+            let err = RunConfig::from_policy("true".to_string(), policy)
+                .expect_err("non-domain allow entry must fail");
+
+            assert!(
+                err.to_string().contains(expected),
+                "unexpected error for {entry:?}: {err:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn policy_allow_list_entries_are_trimmed() {
+        let policy = parse_policy_yaml(
+            r#"
+network:
+  allow:
+    - "  api.github.com  "
+"#,
+        )
+        .expect("policy yaml");
+
+        let config = RunConfig::from_policy("true".to_string(), policy).expect("policy parses");
+
+        assert_eq!(
+            config.network,
+            NetworkPolicy::AllowDomains(vec!["api.github.com".to_string()])
+        );
     }
 
     #[test]

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1,4 +1,4 @@
-use crate::config::{NetworkPolicy, RunConfig};
+use crate::config::{NetworkPolicy, RunConfig, SupportedInjectMode};
 use crate::secrets::SealedCredentials;
 use anyhow::{Context, Result};
 use serde::Serialize;
@@ -55,9 +55,10 @@ struct Network {
 struct CustomCredential {
     upstream: String,
     credential_key: String,
-    inject_mode: String,
+    inject_mode: SupportedInjectMode,
     inject_header: &'static str,
-    credential_format: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    credential_format: Option<&'static str>,
     env_var: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     tls_ca: Option<String>,
@@ -84,14 +85,19 @@ pub fn build_profile(config: &RunConfig, sealed: &SealedCredentials) -> Result<N
             allow_domains.insert(host.to_string());
         }
         credentials.push(credential.name.clone());
+
+        let credential_format = match credential.inject_mode {
+            SupportedInjectMode::Header => Some("Bearer {}"),
+            SupportedInjectMode::BasicAuth => None,
+        };
         custom_credentials.insert(
             credential.name.clone(),
             CustomCredential {
                 upstream: credential.upstream.clone(),
                 credential_key: format!("file://{}", credential.credential_file.display()),
-                inject_mode: credential.inject_mode.clone(),
+                inject_mode: credential.inject_mode,
                 inject_header: "Authorization",
-                credential_format: "Bearer {}",
+                credential_format,
                 env_var: credential.secret_env.clone(),
                 tls_ca: credential.tls_ca.clone(),
                 endpoint_rules: credential.endpoint_rules.clone(),
@@ -182,7 +188,7 @@ pub fn write_profile(path: &Path, profile: &NonoProfile) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{NetworkPolicy, RunConfig};
+    use crate::config::{NetworkPolicy, RunConfig, SupportedInjectMode};
     use crate::secrets::{SealedCredential, SealedCredentials};
     use std::collections::BTreeMap;
 
@@ -234,7 +240,7 @@ mod tests {
                 secret_env: "CARGO_REGISTRY_TOKEN".to_string(),
                 upstream: "https://crates.io".to_string(),
                 tls_ca: None,
-                inject_mode: "header".to_string(),
+                inject_mode: SupportedInjectMode::Header,
                 credential_file: dir.path().join("cratesio"),
                 endpoint_rules: Vec::new(),
             }],
@@ -266,7 +272,7 @@ mod tests {
                 secret_env: "CARGO_REGISTRY_TOKEN".to_string(),
                 upstream: "https://crates.io".to_string(),
                 tls_ca: None,
-                inject_mode: "header".to_string(),
+                inject_mode: SupportedInjectMode::Header,
                 credential_file: dir.path().join("cratesio"),
                 endpoint_rules: Vec::new(),
             }],
@@ -299,7 +305,7 @@ mod tests {
                 secret_env: "CARGO_REGISTRY_TOKEN".to_string(),
                 upstream: "https://crates.io".to_string(),
                 tls_ca: None,
-                inject_mode: "header".to_string(),
+                inject_mode: SupportedInjectMode::Header,
                 credential_file,
                 endpoint_rules: Vec::new(),
             }],
@@ -337,7 +343,7 @@ mod tests {
                 secret_env: "CARGO_REGISTRY_TOKEN".to_string(),
                 upstream: "https://crates.io".to_string(),
                 tls_ca: None,
-                inject_mode: "header".to_string(),
+                inject_mode: SupportedInjectMode::Header,
                 credential_file: dir.path().join("cratesio"),
                 endpoint_rules: Vec::new(),
             }],

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -1,4 +1,4 @@
-use crate::config::RunConfig;
+use crate::config::{RunConfig, SupportedInjectMode};
 use anyhow::{bail, Context, Result};
 use std::collections::{BTreeMap, HashSet};
 use std::env;
@@ -19,7 +19,7 @@ pub struct SealedCredential {
     pub secret_env: String,
     pub upstream: String,
     pub tls_ca: Option<String>,
-    pub inject_mode: String,
+    pub inject_mode: SupportedInjectMode,
     pub credential_file: std::path::PathBuf,
     pub endpoint_rules: Vec<crate::config::EndpointRule>,
 }
@@ -50,7 +50,7 @@ pub fn seal_credentials(config: &RunConfig) -> Result<SealedCredentials> {
         if secret.is_empty() {
             bail!("access secret env var '{}' is empty", grant.secret);
         }
-        validate_secret_for_inject_mode(&grant.secret, &grant.inject_mode, &secret)?;
+        validate_secret_for_inject_mode(&grant.secret, grant.inject_mode, &secret)?;
         emit_secret_masks(&secret);
 
         let name = grant.name.clone();
@@ -63,7 +63,7 @@ pub fn seal_credentials(config: &RunConfig) -> Result<SealedCredentials> {
             secret_env: grant.secret.clone(),
             upstream: grant.upstream.clone(),
             tls_ca: grant.tls_ca.clone(),
-            inject_mode: grant.inject_mode.clone(),
+            inject_mode: grant.inject_mode,
             credential_file: path,
             endpoint_rules: grant.endpoint_rules.clone(),
         });
@@ -107,10 +107,16 @@ fn validate_access_grant_name(name: &str) -> Result<()> {
 
 fn validate_secret_for_inject_mode(
     secret_env: &str,
-    inject_mode: &str,
+    inject_mode: SupportedInjectMode,
     secret: &str,
 ) -> Result<()> {
-    if inject_mode == "header" && secret.contains(['\r', '\n']) {
+    let secret_lands_in_header_verbatim = match inject_mode {
+        SupportedInjectMode::Header => true,
+        // nono base64-encodes basic_auth secrets, so a newline never reaches
+        // the header.
+        SupportedInjectMode::BasicAuth => false,
+    };
+    if secret_lands_in_header_verbatim && secret.contains(['\r', '\n']) {
         bail!(
             "access secret env var '{secret_env}' contains a newline, which cannot be injected as an HTTP header"
         );
@@ -131,7 +137,7 @@ fn secret_mask_lines(secret: &str) -> impl Iterator<Item = &str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{AccessConfig, AuditConfig, NetworkPolicy};
+    use crate::config::{AccessConfig, AuditConfig, NetworkPolicy, SupportedInjectMode};
     use std::ffi::OsString;
     use std::os::unix::ffi::OsStringExt;
 
@@ -173,7 +179,7 @@ mod tests {
                 secret: "RUNSEAL_TEST_SECRET_THAT_IS_NOT_SET".to_string(),
                 upstream: "https://crates.io".to_string(),
                 tls_ca: None,
-                inject_mode: "header".to_string(),
+                inject_mode: SupportedInjectMode::Header,
                 endpoint_rules: Vec::new(),
             }],
             audit: AuditConfig::Disabled,
@@ -217,8 +223,12 @@ mod tests {
 
     #[test]
     fn header_injection_rejects_newline_secrets() {
-        let err = validate_secret_for_inject_mode("RUNSEAL_TEST_SECRET", "header", "first\nsecond")
-            .expect_err("header secrets with newlines must fail");
+        let err = validate_secret_for_inject_mode(
+            "RUNSEAL_TEST_SECRET",
+            SupportedInjectMode::Header,
+            "first\nsecond",
+        )
+        .expect_err("header secrets with newlines must fail");
 
         assert!(
             err.to_string()
@@ -228,8 +238,12 @@ mod tests {
     }
 
     #[test]
-    fn non_header_injection_allows_newline_secrets() {
-        validate_secret_for_inject_mode("RUNSEAL_TEST_SECRET", "body", "first\nsecond")
-            .expect("non-header multiline secret");
+    fn basic_auth_injection_allows_newline_secrets() {
+        validate_secret_for_inject_mode(
+            "RUNSEAL_TEST_SECRET",
+            SupportedInjectMode::BasicAuth,
+            "first\nsecond",
+        )
+        .expect("basic_auth multiline secret");
     }
 }

--- a/tests/profile_json.rs
+++ b/tests/profile_json.rs
@@ -91,6 +91,37 @@ access:
     );
 }
 
+#[test]
+fn invalid_inject_mode_fails_before_spawning_nono() {
+    let policy = r#"
+network:
+  mode: blocked
+access:
+  cratesio:
+    secret: CARGO_REGISTRY_TOKEN
+    url: https://crates.io
+    inject:
+      mode: heder
+    allow:
+      - GET /api/v1/crates
+"#;
+    let run = run_with_fake_nono(policy);
+
+    assert!(
+        !run.output.status.success(),
+        "runseal must reject an invalid inject mode"
+    );
+    assert!(
+        !run.captured_args.exists(),
+        "nono must not be spawned when the policy is invalid"
+    );
+    let stderr = String::from_utf8_lossy(&run.output.stderr);
+    assert!(
+        stderr.contains("not valid runseal policy YAML"),
+        "unexpected stderr:\n{stderr}"
+    );
+}
+
 struct FakeNonoRun {
     output: std::process::Output,
     captured_profile: PathBuf,

--- a/tests/profile_json.rs
+++ b/tests/profile_json.rs
@@ -31,6 +31,14 @@ access:
     let json = read_profile_json(&run.captured_profile);
 
     assert_eq!(json["network"]["block"], true);
+    assert_eq!(
+        json["network"]["custom_credentials"]["cratesio"]["endpoint_rules"][0]["method"],
+        "GET"
+    );
+    assert_eq!(
+        json["network"]["custom_credentials"]["cratesio"]["inject_mode"],
+        "header"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Swaps unchecked string inputs for configs to parsed enums