### PR TITLE
fix(lint): actually enforce clippy::unwrap_used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,8 @@ serde_json = "1"
 serde_yaml_ng = "0.10"
 tempfile = "3"
 
+[lints]
+workspace = true
+
 [workspace.lints.clippy]
 unwrap_used = "deny"

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ check: clippy fmt-check
 lint: check
 
 clippy:
-	$(CARGO) clippy --all-targets --locked -- -D warnings
+	$(CARGO) clippy --all-targets --locked -- -D warnings -D clippy::unwrap_used
 
 fmt:
 	$(CARGO) fmt --all

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -271,6 +271,8 @@ mod tests {
 
     #[test]
     fn empty_json_list_output_has_no_sessions() {
-        assert!(parse_audit_list_json("").unwrap().is_empty());
+        assert!(parse_audit_list_json("")
+            .expect("empty output parses")
+            .is_empty());
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -180,7 +180,7 @@ mod tests {
     fn read_directory_uses_read_flag() {
         let dir = tempfile::tempdir().expect("tempdir");
         assert_eq!(
-            fs_flag(path_str(dir.path()), FsAccess::Read).unwrap(),
+            fs_flag(path_str(dir.path()), FsAccess::Read).expect("read flag for directory"),
             "--read"
         );
     }
@@ -192,7 +192,7 @@ mod tests {
         fs::write(&file, "allowed").expect("write file");
 
         assert_eq!(
-            fs_flag(path_str(&file), FsAccess::Read).unwrap(),
+            fs_flag(path_str(&file), FsAccess::Read).expect("read flag for file"),
             "--read-file"
         );
     }
@@ -201,7 +201,7 @@ mod tests {
     fn write_directory_uses_write_flag() {
         let dir = tempfile::tempdir().expect("tempdir");
         assert_eq!(
-            fs_flag(path_str(dir.path()), FsAccess::Write).unwrap(),
+            fs_flag(path_str(dir.path()), FsAccess::Write).expect("write flag for directory"),
             "--write"
         );
     }
@@ -213,7 +213,7 @@ mod tests {
         fs::write(&file, "old").expect("write file");
 
         assert_eq!(
-            fs_flag(path_str(&file), FsAccess::Write).unwrap(),
+            fs_flag(path_str(&file), FsAccess::Write).expect("write flag for file"),
             "--write-file"
         );
     }
@@ -223,7 +223,8 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let missing = dir.path().join("missing.txt");
 
-        let err = fs_flag(path_str(&missing), FsAccess::Read).unwrap_err();
+        let err =
+            fs_flag(path_str(&missing), FsAccess::Read).expect_err("missing read path must fail");
         assert!(err.to_string().contains("does not exist"));
     }
 


### PR DESCRIPTION
## Summary

Enforces `unwrap_unused` lint

## Test Plan

`make ci`

## Checklist

- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([AGENTS.md](AGENTS.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
