### PR TITLE
feat(secrets): zeroize secrets in memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "tempfile",
+ "zeroize",
 ]
 
 [[package]]
@@ -481,6 +482,12 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml_ng = "0.10"
 tempfile = "3"
+zeroize = "1"
 
 [lints]
 workspace = true

--- a/README.md
+++ b/README.md
@@ -130,7 +130,9 @@ Each key under `access` is a named grant. `secret` is the environment variable
 containing the real secret, `url` is the service base URL, and `allow` lists the
 HTTP routes where the secret may be injected. Runseal masks the secret in logs,
 writes it to a private file, removes it from the child environment, and
-configures `nono` to inject it through the local proxy.
+configures `nono` to inject it through the local proxy. Runseal's own copy of
+the plaintext is zeroed out of memory once the credential file is written, and
+on every error path in between.
 
 ```yaml
 access:

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -1,10 +1,18 @@
+//! Credential sealing for sandboxed runs.
+
 use crate::config::{RunConfig, SupportedInjectMode};
 use anyhow::{bail, Context, Result};
 use std::collections::{BTreeMap, HashSet};
 use std::env;
+use std::ffi::OsString;
 use std::fs;
+use std::io::{self, Write};
+use std::os::unix::ffi::OsStringExt;
 use std::os::unix::fs::PermissionsExt;
 use tempfile::TempDir;
+use zeroize::Zeroizing;
+
+const MASK_PREFIX: &str = "::add-mask::";
 
 #[derive(Debug)]
 pub struct SealedCredentials {
@@ -31,16 +39,7 @@ pub fn seal_credentials(config: &RunConfig) -> Result<SealedCredentials> {
     fs::set_permissions(dir.path(), fs::Permissions::from_mode(0o700))?;
 
     let secret_names: HashSet<&str> = config.access.iter().map(|c| c.secret.as_str()).collect();
-    let sanitized_env: BTreeMap<String, String> = env::vars_os()
-        .filter_map(|(key, value)| {
-            let key = key.into_string().ok()?;
-            let value = value.into_string().ok()?;
-            Some((key, value))
-        })
-        .filter(|(key, _)| !secret_names.contains(key.as_str()))
-        .filter(|(key, _)| !key.starts_with("RUNSEAL_"))
-        .filter(|(key, _)| !key.starts_with("NONO_ACTION_"))
-        .collect();
+    let sanitized_env = sanitize_env(&secret_names);
 
     let mut sealed = Vec::new();
     for grant in &config.access {
@@ -51,7 +50,7 @@ pub fn seal_credentials(config: &RunConfig) -> Result<SealedCredentials> {
             bail!("access secret env var '{}' is empty", grant.secret);
         }
         validate_secret_for_inject_mode(&grant.secret, grant.inject_mode, &secret)?;
-        emit_secret_masks(&secret);
+        emit_secret_masks(&secret)?;
 
         let name = grant.name.clone();
         let path = dir.path().join(&name);
@@ -76,16 +75,56 @@ pub fn seal_credentials(config: &RunConfig) -> Result<SealedCredentials> {
     })
 }
 
-fn read_secret_env(secret_env: &str) -> Result<String> {
+/// Sanitize the environment, discarding secrets and internal inputs.
+fn sanitize_env(secret_names: &HashSet<&str>) -> BTreeMap<String, String> {
+    let mut sanitized = BTreeMap::new();
+    for (key, value) in env::vars_os() {
+        let Ok(key) = key.into_string() else {
+            discard_secret_bytes(value);
+            continue;
+        };
+        if !is_forwarded_env_key(&key, secret_names) {
+            discard_secret_bytes(value);
+            continue;
+        }
+        match value.into_string() {
+            Ok(value) => {
+                sanitized.insert(key, value);
+            }
+            Err(value) => discard_secret_bytes(value),
+        }
+    }
+    sanitized
+}
+
+/// Whether an environment variable may be forwarded into the sandbox.
+///
+/// Secrets are withheld because the credential proxy injects them instead, and
+/// runseal's own inputs are withheld because the sandboxed command has no
+/// business reading the policy it is confined by.
+fn is_forwarded_env_key(key: &str, secret_names: &HashSet<&str>) -> bool {
+    !secret_names.contains(key) && !key.starts_with("RUNSEAL_") && !key.starts_with("NONO_ACTION_")
+}
+
+/// Zeroize the provided OsString.
+fn discard_secret_bytes(value: OsString) {
+    drop(Zeroizing::new(value.into_vec()));
+}
+
+fn read_secret_env(secret_env: &str) -> Result<Zeroizing<String>> {
     let value = env::var_os(secret_env)
         .with_context(|| format!("access secret env var '{secret_env}' is not set"))?;
     decode_secret_env_value(secret_env, value)
 }
 
-fn decode_secret_env_value(secret_env: &str, value: std::ffi::OsString) -> Result<String> {
+/// Read and decode a secret environment variable.
+fn decode_secret_env_value(secret_env: &str, value: OsString) -> Result<Zeroizing<String>> {
     match value.into_string() {
-        Ok(value) => Ok(value),
-        Err(_) => bail!("access secret env var '{secret_env}' is not valid UTF-8"),
+        Ok(value) => Ok(Zeroizing::new(value)),
+        Err(value) => {
+            discard_secret_bytes(value);
+            bail!("access secret env var '{secret_env}' is not valid UTF-8")
+        }
     }
 }
 
@@ -124,10 +163,31 @@ fn validate_secret_for_inject_mode(
     Ok(())
 }
 
-fn emit_secret_masks(secret: &str) {
+fn emit_secret_masks(secret: &str) -> Result<()> {
+    let mut stdout = io::stdout().lock();
     for line in secret_mask_lines(secret) {
-        println!("::add-mask::{line}");
+        let masked = mask_line(line);
+        stdout
+            .write_all(masked.as_bytes())
+            .context("failed to write secret mask")?;
     }
+    // Masks must reach the log before the secret can appear anywhere else.
+    stdout.flush().context("failed to flush secret masks")?;
+    Ok(())
+}
+
+/// Render a newline-terminated mask command.
+fn mask_line(line: &str) -> Zeroizing<String> {
+    let mut masked = Zeroizing::new(String::with_capacity(
+        MASK_PREFIX
+            .len()
+            .saturating_add(line.len())
+            .saturating_add(1),
+    ));
+    masked.push_str(MASK_PREFIX);
+    masked.push_str(line);
+    masked.push('\n');
+    masked
 }
 
 fn secret_mask_lines(secret: &str) -> impl Iterator<Item = &str> {
@@ -212,6 +272,54 @@ mod tests {
             !rendered.contains("RAWKEY"),
             "error leaked secret suffix: {rendered}"
         );
+    }
+
+    #[test]
+    fn utf8_secret_decodes_into_scrubbing_string() {
+        let value = OsString::from("s3cret-value");
+
+        let secret = decode_secret_env_value("RUNSEAL_TEST_SECRET", value).expect("utf-8 secret");
+
+        assert_eq!(&*secret, "s3cret-value");
+    }
+
+    #[test]
+    fn forwards_ordinary_env_keys_to_the_sandbox() {
+        let secret_names = HashSet::from(["CARGO_REGISTRY_TOKEN"]);
+
+        for key in ["PATH", "HOME", "GITHUB_WORKSPACE", "RUNSEALED", "NONO_HOME"] {
+            assert!(
+                is_forwarded_env_key(key, &secret_names),
+                "expected {key} to be forwarded"
+            );
+        }
+    }
+
+    #[test]
+    fn withholds_secret_and_runseal_env_keys_from_the_sandbox() {
+        let secret_names = HashSet::from(["CARGO_REGISTRY_TOKEN"]);
+
+        for key in [
+            "CARGO_REGISTRY_TOKEN",
+            "RUNSEAL_ACCESS",
+            "RUNSEAL_",
+            "NONO_ACTION_PROFILE",
+        ] {
+            assert!(
+                !is_forwarded_env_key(key, &secret_names),
+                "expected {key} to be withheld"
+            );
+        }
+    }
+
+    #[test]
+    fn mask_line_is_newline_terminated_and_exactly_sized() {
+        let masked = mask_line("s3cret-value");
+
+        assert_eq!(&*masked, "::add-mask::s3cret-value\n");
+        // An exact capacity means no reallocation left a copy of the secret
+        // behind in a buffer nothing scrubs.
+        assert_eq!(masked.capacity(), masked.len());
     }
 
     #[test]


### PR DESCRIPTION


## Summary

Wraps secrets in memory in `Zeroize<T>`

## Test Plan

`make ci`

## Checklist

- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([AGENTS.md](AGENTS.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
