### PR TITLE
chore(deps): track nono releases with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,16 @@ updates:
       rust-dependencies:
         patterns:
           - "*"
+
+  # The nono release binary this action installs.
+  - package-ecosystem: cargo
+    directory: /.github/nono-version
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: "chore(nono)"
+    labels:
+      - dependencies
+      - nono
+    allow:
+      - dependency-name: nono-cli

--- a/.github/nono-version/Cargo.toml
+++ b/.github/nono-version/Cargo.toml
@@ -1,0 +1,24 @@
+# Dependabot's handle on the nono release that this action pins.
+#
+# The requirement below names a crates.io version of nono-cli, but setup.sh
+# installs the GitHub release binary `v<version>` from nolabs-ai/nono. Nothing
+# in Cargo guarantees those stay in step, so .github/workflows/nono-pin.yml
+# enforces the coupling: a matching attested release must exist, the installed
+# binary must report this version, and a nono release that never reached
+# crates.io (which Dependabot cannot see) is reported instead of ignored.
+[package]
+name = "runseal-nono-pin"
+version = "0.0.0"
+edition = "2021"
+license = "Apache-2.0"
+publish = false
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+# Keep this as an inline exact-version string: scripts/nono-pinned-version.sh
+# parses this literal form and fails closed on anything else.
+nono-cli = "=0.75.0"
+
+[workspace]

--- a/.github/workflows/nono-pin.yml
+++ b/.github/workflows/nono-pin.yml
@@ -1,0 +1,165 @@
+name: nono Pin
+
+# Guards the Dependabot-managed nono pin in .github/nono-version/Cargo.toml.
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/nono-version/**'
+      - '.github/workflows/nono-pin.yml'
+      - 'scripts/nono-pinned-version.sh'
+      - 'setup.sh'
+      - 'action.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.github/nono-version/**'
+      - '.github/workflows/nono-pin.yml'
+      - 'scripts/nono-pinned-version.sh'
+      - 'setup.sh'
+      - 'action.yml'
+  schedule:
+    # Daily, shortly after Dependabot's daily check on the pin directory.
+    - cron: '17 6 * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nono-pin-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pin-script:
+    name: Pin resolver
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.pin.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Resolver prints a usable version
+        id: pin
+        run: |
+          version="$(scripts/nono-pinned-version.sh)"
+          echo "resolved ${version}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Resolver rejects a bad manifest
+        run: |
+          printf 'nono-cli = "0.62.0"\n' > "${RUNNER_TEMP}/loose.toml"
+          if scripts/nono-pinned-version.sh "${RUNNER_TEMP}/loose.toml"; then
+            echo "expected failure on non-exact requirement" >&2
+            exit 1
+          fi
+
+  # Builds runseal from source and runs the action for real.
+  default-pin:
+    name: Action uses the pin by default
+    runs-on: ubuntu-latest
+    needs: pin-script
+    if: github.event_name != 'schedule'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # The pinned version is validated as a bare X.Y.Z by
+      # scripts/nono-pinned-version.sh before it reaches this interpolation.
+      - name: Run with no nono-version input
+        uses: ./
+        with:
+          runseal-version: source
+          run: |
+            nono --version
+            nono --version | grep -F '${{ needs.pin-script.outputs.version }}'
+            printf "sandbox ok\n"
+          policy: |
+            fs:
+              read: ["."]
+              write: []
+            network:
+              mode: blocked
+
+  explicit-override:
+    name: Explicit nono-version still wins
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run with an explicit nono-version
+        uses: ./
+        with:
+          runseal-version: source
+          nono-version: "0.74.0"
+          run: |
+            nono --version | grep -F 0.74.0
+            printf "override ok\n"
+          policy: |
+            fs:
+              read: ["."]
+              write: []
+            network:
+              mode: blocked
+
+  # Upstream drift
+  pin-freshness:
+    name: Pin tracks published nono releases
+    runs-on: ubuntu-latest
+    needs: pin-script
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Compare pin with the latest nono release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PINNED: ${{ needs.pin-script.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          read -r tag published < <(
+            gh release view --repo nolabs-ai/nono \
+              --json tagName,publishedAt \
+              --jq '[.tagName, .publishedAt] | @tsv'
+          )
+          latest="${tag#v}"
+
+          if [[ "${latest}" == "${PINNED}" ]]; then
+            echo "pin ${PINNED} is the latest nono release"
+            exit 0
+          fi
+
+          # Dependabot can only see versions published to crates.io. If the
+          # newest release never made it to the registry, the pin is stuck and
+          # no bump PR will ever arrive.
+          status="$(
+            curl -sS -o /dev/null -w '%{http_code}' \
+              -H 'User-Agent: runseal-ci (https://github.com/nolabs-ai/runseal)' \
+              "https://crates.io/api/v1/crates/nono-cli/${latest}"
+          )"
+
+          if [[ "${status}" == "200" ]]; then
+            echo "::warning::Pin is ${PINNED}; nono ${latest} is published to crates.io. Expect a Dependabot bump PR."
+            exit 0
+          fi
+
+          if [[ "${status}" != "404" ]]; then
+            echo "::error::crates.io lookup for nono-cli ${latest} returned HTTP ${status}" >&2
+            exit 1
+          fi
+
+          # Allow a grace window for the crates.io publish to follow the release.
+          published_epoch="$(date -u -d "${published}" +%s)"
+          now_epoch="$(date -u +%s)"
+          age_hours="$(( (now_epoch - published_epoch) / 3600 ))"
+
+          if (( age_hours < 48 )); then
+            echo "::notice::nono ${latest} was released ${age_hours}h ago and is not on crates.io yet; pin stays at ${PINNED}."
+            exit 0
+          fi
+
+          echo "::error::nono ${latest} was released ${age_hours}h ago but nono-cli ${latest} is not on crates.io, so Dependabot cannot bump the pin (still ${PINNED}). Publish the crate or update .github/nono-version/Cargo.toml by hand." >&2
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target/
 /.DS_Store
 /runseal-lab/
+/.github/nono-version/Cargo.lock

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ still allowing L7 policy enforcement.
 | `fs-write` | No | empty | Comma-separated write paths when `policy` is not set. |
 | `network` | No | `blocked` | Network policy when `policy` is not set: `blocked` or comma-separated domains. `filtered` is only valid as `network.mode` inside `policy` and is rejected here. |
 | `runseal-version` | No | `0.3.3` | Runseal release version to install. Accepts `v0.1.0` or `0.1.0`. |
-| `nono-version` | No | `0.62.0` | nono release version to install. Accepts `v0.1.0` or `0.1.0`. |
+| `nono-version` | No | pinned | nono release version to install. Defaults to the Dependabot-managed pin in `.github/nono-version/Cargo.toml`. Accepts `v0.1.0` or `0.1.0`. |
 | `verify-attestations` | No | `true` | Verify GitHub artifact attestations for downloaded release assets. |
 | `audit` | No | `false` | Set to `artifact` or `true` to upload nono audit evidence as a GitHub Actions artifact. |
 

--- a/action.yml
+++ b/action.yml
@@ -30,9 +30,9 @@ inputs:
     required: false
     default: "0.3.3"
   nono-version:
-    description: "nono version to install, without or with leading v"
+    description: "nono version to install. Defaults to the Dependabot-managed pin."
     required: false
-    default: "0.62.0"
+    default: ""
   verify-attestations:
     description: "Verify GitHub artifact attestations for downloaded runseal and nono release assets"
     required: false

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 #
 # Fails if the runseal or nono version drifts between the places that pin it.
-# Cargo.toml is the source of truth for runseal, setup.sh for nono.
+# Cargo.toml is the source of truth for runseal; .github/nono-version/Cargo.toml
+# is the Dependabot-managed source of truth for nono.
 
 set -euo pipefail
 
@@ -40,13 +41,11 @@ if [[ -z "${RUNSEAL_VERSION}" ]]; then
     exit 1
 fi
 
-NONO_VERSION="$(extract '^NONO_VERSION="\$\{NONO_VERSION:-([0-9]+\.[0-9]+\.[0-9]+)\}"$' setup.sh)"
-if [[ -z "${NONO_VERSION}" ]]; then
-    fail "could not read the pinned nono version from setup.sh"
-    exit 1
-fi
+NONO_MANIFEST=".github/nono-version/Cargo.toml"
+NONO_VERSION="$(bash scripts/nono-pinned-version.sh)"
 
-printf 'runseal %s (Cargo.toml) · nono %s (setup.sh)\n\n' "${RUNSEAL_VERSION}" "${NONO_VERSION}"
+printf 'runseal %s (Cargo.toml) · nono %s (%s)\n\n' \
+    "${RUNSEAL_VERSION}" "${NONO_VERSION}" "${NONO_MANIFEST}"
 
 # --- runseal version -------------------------------------------------------
 
@@ -61,11 +60,41 @@ expect "README runseal-version input row" "${RUNSEAL_VERSION}" \
 
 # --- nono version ----------------------------------------------------------
 
-expect "action.yml nono-version default" "${NONO_VERSION}" \
-    "$(sed -nE '/^  nono-version:/,/^  [a-z]/ s/^    default: "([0-9]+\.[0-9]+\.[0-9]+)"$/\1/p' action.yml)"
+# The nono version is single-sourced in ${NONO_MANIFEST} so Dependabot can bump
+# it in one place. Nothing else may restate it: setup.sh and action.yml default to
+# empty and resolve the pin at install time, and the README defers to the manifest.
 
-expect "README nono-version input row" "${NONO_VERSION}" \
-    "$(extract '^\| `nono-version` \| No \| `([0-9]+\.[0-9]+\.[0-9]+)` \|.*$' README.md)"
+# `extract` cannot tell an empty capture from a missing line, so match the whole
+# line: a deleted default must fail here rather than read as "correctly empty".
+if grep -qxF 'NONO_VERSION="${NONO_VERSION:-}"' setup.sh; then
+    ok "setup.sh NONO_VERSION defaults to the pin (empty)"
+else
+    fail "setup.sh must contain the exact line NONO_VERSION=\"\${NONO_VERSION:-}\"; found '$(extract '^(NONO_VERSION=.*)$' setup.sh)'"
+fi
+
+expect "action.yml nono-version default" '""' \
+    "$(sed -nE '/^  nono-version:/,/^  [a-z]/ s/^    default: (.+)$/\1/p' action.yml)"
+
+NONO_README_DEFAULT="$(
+    awk -F'|' '/^\| `nono-version` \|/ {gsub(/^ +| +$/, "", $4); print $4; exit}' README.md
+)"
+if [[ -z "${NONO_README_DEFAULT}" ]]; then
+    fail "README nono-version input row not found"
+elif [[ "${NONO_README_DEFAULT}" =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+    fail "README nono-version default '${NONO_README_DEFAULT}' hardcodes a version; defer to ${NONO_MANIFEST}"
+else
+    ok "README nono-version default defers to the pin (${NONO_README_DEFAULT})"
+fi
+
+NONO_PIN_WORKFLOW=".github/workflows/nono-pin.yml"
+NONO_OVERRIDE="$(extract '^          nono-version: "([0-9]+\.[0-9]+\.[0-9]+)"$' "${NONO_PIN_WORKFLOW}")"
+if [[ -z "${NONO_OVERRIDE}" ]]; then
+    fail "no bare X.Y.Z nono-version override found in ${NONO_PIN_WORKFLOW}"
+elif [[ "${NONO_OVERRIDE}" == "${NONO_VERSION}" ]]; then
+    fail "${NONO_PIN_WORKFLOW} override ${NONO_OVERRIDE} equals the pin; the override job would pass vacuously"
+else
+    ok "nono-pin.yml override ${NONO_OVERRIDE} differs from the pin ${NONO_VERSION}"
+fi
 
 # --- action pins in docs and examples --------------------------------------
 # `@main` and the floating `@v0` tag are exempt; exact pins must be current.

--- a/scripts/nono-pinned-version.sh
+++ b/scripts/nono-pinned-version.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Print the nono version pinned for this action in .github/nono-version/Cargo.toml.
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+manifest="${1:-${script_dir}/../.github/nono-version/Cargo.toml}"
+
+if [[ ! -f "${manifest}" ]]; then
+    echo "::error::nono version pin ${manifest} not found; pass nono-version explicitly" >&2
+    exit 1
+fi
+
+pins="$(sed -n 's/^nono-cli[[:space:]]*=[[:space:]]*"=\([^"]*\)".*$/\1/p' "${manifest}")"
+count=0
+if [[ -n "${pins}" ]]; then
+    count="$(printf '%s\n' "${pins}" | wc -l | tr -d '[:space:]')"
+fi
+
+if [[ "${count}" != "1" ]]; then
+    echo "::error::Expected exactly one exact nono-cli requirement in ${manifest}, found ${count}" >&2
+    exit 1
+fi
+
+version="${pins}"
+
+if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "::error::Pinned nono version '${version}' in ${manifest} is not a bare X.Y.Z version" >&2
+    exit 1
+fi
+
+printf '%s\n' "${version}"

--- a/setup.sh
+++ b/setup.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SETUP_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+
 RUNSEAL_VERSION="${RUNSEAL_VERSION:-0.3.3}"
-NONO_VERSION="${NONO_VERSION:-0.62.0}"
+# Empty means "use the Dependabot-tracked pin"; resolved below via
+# scripts/nono-pinned-version.sh.
+NONO_VERSION="${NONO_VERSION:-}"
 RUNSEAL_REPO="${RUNSEAL_REPO:-nolabs-ai/runseal}"
 NONO_REPO="${NONO_REPO:-nolabs-ai/nono}"
 RUNSEAL_VERIFY_ATTESTATIONS="${RUNSEAL_VERIFY_ATTESTATIONS:-true}"
@@ -229,6 +233,11 @@ TARGET="$(detect_target)"
 
 mkdir -p "${HOME}/.nono/sessions"
 chmod 700 "${HOME}/.nono" "${HOME}/.nono/sessions"
+
+if [[ -z "${NONO_VERSION}" ]]; then
+    NONO_VERSION="$(bash "${SETUP_DIR}/scripts/nono-pinned-version.sh")"
+    echo "Using pinned nono version ${NONO_VERSION}"
+fi
 
 install_release_binary "nono" "${NONO_REPO}" "${NONO_VERSION}" "${TARGET}"
 


### PR DESCRIPTION
## Summary
Add Dependabot support for updating the nono version

## Test Plan
Expect PR after merge

## Checklist

- [x] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [x] All new code follows the project's coding standards ([AGENTS.md](AGENTS.md)) and is covered by tests
- [x] Public-facing changes are paired with documentation updates
